### PR TITLE
StreamPix 6 compatibility

### DIFF
--- a/norpix.py
+++ b/norpix.py
@@ -43,7 +43,11 @@ class SeqFile(object):
         self.imfloat = SeqImageFloat(self)
         # Format parameters
         self.bpp = h['BitDepth']
-        self._imageOffset = h['HeaderSize']
+        if h['Version'] == 5: # if StreamPix version 6
+            self._imageOffset = 8192
+        else: # previous versions
+            self._imageOffset = 1024
+#        self._imageOffset = h._imageOffset # h['HeaderSize']
         self._imageBlockSize = h['TrueImageSize']
         self.filesize = os.stat(filename).st_size
         self.imageCount = (self.filesize - h['HeaderSize']) / h['TrueImageSize']

--- a/norpix.py
+++ b/norpix.py
@@ -47,7 +47,6 @@ class SeqFile(object):
             self._imageOffset = 8192
         else: # previous versions
             self._imageOffset = 1024
-#        self._imageOffset = h._imageOffset # h['HeaderSize']
         self._imageBlockSize = h['TrueImageSize']
         self.filesize = os.stat(filename).st_size
         self.imageCount = (self.filesize - h['HeaderSize']) / h['TrueImageSize']


### PR DESCRIPTION
Added compatibility with the latest StreamPix version (6), which aligns
the image data on a 8192 bytes boundary.
